### PR TITLE
Fix scan area AABB

### DIFF
--- a/src/main/java/link/infra/demagnetize/blocks/DemagnetizerTileEntity.java
+++ b/src/main/java/link/infra/demagnetize/blocks/DemagnetizerTileEntity.java
@@ -92,8 +92,7 @@ public class DemagnetizerTileEntity extends TileEntity implements ITickableTileE
 	}
 
 	private void updateBoundingBox() {
-		int negRange = range * -1;
-		scanArea = new AxisAlignedBB(getPos().add(negRange, negRange, negRange), getPos().add(range, range, range));
+		scanArea = new AxisAlignedBB(getPos()).grow(range);
 	}
 
 	// Ensure that the new bounding box is updated


### PR DESCRIPTION
Positive side of the AABB had one block less range than expected.

This PR switches to using the AABB constructor that creates an AABB from a `BlockPos` that results in a `1^3` cube centered on the `BlockPos` passed in. (That would be `(0.5, 0.5, 0.5)` for `BlockPos(0, 0, 0)`.)
It then applies `grow(range)`, resulting in a `(range*2 + 1)^3` cube, still centered on `(0.5, 0.5, 0.5)`.

Example of old behaviour for range of 4 with `BlockPos(0, 0, 0)` that will be fixed by this PR:
```java
int negRange = range * -1;
scanArea = new AxisAlignedBB(getPos().add(negRange, negRange, negRange), getPos().add(range, range, range));
```
```java
scanArea = new AxisAlignedBB(getPos().add(-4, -4, -4), getPos().add(4, 4, 4));
```
Which is an `8^3` cube, centred on `(0, 0, 0)` but we expected a `9^3` cube centered on `(0.5, 0.5, 0.5)`
